### PR TITLE
Allow `generate` to be called from other directory

### DIFF
--- a/generate
+++ b/generate
@@ -2,6 +2,7 @@
 # Diceware password generator in Python, in one tweet.
 # (words file is http://world.std.com/~reinhold/beale.wordlist.asc)
 # Because I have no dice:
-import random
-w = [s.split()[1] for s in open('words') if s[0] in '123456']
+import random, os
+path = os.path.dirname(os.path.realpath(__file__))
+w = [s.split()[1] for s in open(os.path.join(path, 'words')) if s[0] in '123456']
 for i in range(5): print random.SystemRandom().choice(w),


### PR DESCRIPTION
This enables you to symlink `generate` into your PATH somewhere
(e.g. ~/bin/diceware) and have it still work.
