### PR TITLE
Allow `generate` to be called from other directory, short version

### DIFF
--- a/checksize
+++ b/checksize
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+import sys
+
+MAX = 140
+count = sum(len(line) for line in open('generate') if not line.startswith('#'))
+if count > MAX:
+    sys.exit('Too large: ' + str(count) + ' characters')
+else:
+    print 'All is good, only', count, 'characters'

--- a/generate
+++ b/generate
@@ -2,7 +2,6 @@
 # Diceware password generator in Python, in one tweet.
 # (words file is http://world.std.com/~reinhold/beale.wordlist.asc)
 # Because I have no dice:
-import random, os
-path = os.path.dirname(os.path.realpath(__file__))
-w = [s.split()[1] for s in open(os.path.join(path, 'words')) if s[0] in '123456']
+import random, sys
+w = [s.split()[1] for s in open(sys.path[0] + '/words')]
 for i in range(5): print random.SystemRandom().choice(w),

--- a/generate
+++ b/generate
@@ -2,6 +2,7 @@
 # Diceware password generator in Python, in one tweet.
 # (words file is http://world.std.com/~reinhold/beale.wordlist.asc)
 # Because I have no dice:
-import random
-w = [s.split()[1] for s in open('words') if s[0] in '123456']
+import random, os
+path = os.path.dirname(os.path.realpath(__file__))
+w = [s.split()[1] for s in open(os.path.join(path, 'words')) if s[0] in '123456']
 for i in range(5): print random.SystemRandom().choice(w),


### PR DESCRIPTION
This is the same patch as PR #1. But it keeps the source code under 140 characters. In addition, this adds `./checksize` script that prints how many non-comment characters `generate` has.
